### PR TITLE
Update lob to be compatible with latest serde

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, NaiveDate, Utc};
-use serde::export::Formatter;
+use std::fmt::Formatter;
 use serde::{ser::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
 use std::fmt;


### PR DESCRIPTION
The Formatter export from serde was just a reexport of std::fmt::Formatter for private usage within serde. See the source [here](https://github.com/serde-rs/serde/blob/b0c99ed761d638f2ca2f0437522e6c35ad254d93/serde/src/lib.rs#L1570).